### PR TITLE
Add "join table" for visits

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -104,4 +104,7 @@ VALUES
 
     INSERT INTO specializations (vet_id, species_id)
     VALUES ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), 1);
- 
+    
+    --  Vet Jack Harkness is specialized in Digimon.
+    INSERT INTO specializations (vet_id, species_id)
+    VALUES ((SELECT id FROM vets WHERE name = 'Jack Harkness'), 2);

--- a/data.sql
+++ b/data.sql
@@ -108,3 +108,50 @@ VALUES
     --  Vet Jack Harkness is specialized in Digimon.
     INSERT INTO specializations (vet_id, species_id)
     VALUES ((SELECT id FROM vets WHERE name = 'Jack Harkness'), 2);
+
+
+-- Insert the following data for visits:
+
+    --  Agumon visited William Tatcher on May 24th, 2020.
+    --  Agumon visited Stephanie Mendez on Jul 22th, 2020.
+    --  Gabumon visited Jack Harkness on Feb 2nd, 2021.
+    --  Pikachu visited Maisy Smith on Jan 5th, 2020.
+    --  Pikachu visited Maisy Smith on Mar 8th, 2020.
+    --  Pikachu visited Maisy Smith on May 14th, 2020.
+    --  Devimon visited Stephanie Mendez on May 4th, 2021.
+    --  Charmander visited Jack Harkness on Feb 24th, 2021.
+    --  Plantmon visited Maisy Smith on Dec 21st, 2019.
+    --  Plantmon visited William Tatcher on Aug 10th, 2020.
+    --  Plantmon visited Maisy Smith on Apr 7th, 2021.
+    --  Squirtle visited Stephanie Mendez on Sep 29th, 2019.
+    --  Angemon visited Jack Harkness on Oct 3rd, 2020.
+    --  Angemon visited Jack Harkness on Nov 4th, 2020.
+    --  Boarmon visited Maisy Smith on Jan 24th, 2019.
+    --  Boarmon visited Maisy Smith on May 15th, 2019.
+    --  Boarmon visited Maisy Smith on Feb 27th, 2020.
+    --  Boarmon visited Maisy Smith on Aug 3rd, 2020.
+    --  Blossom visited Stephanie Mendez on May 24th, 2020.
+    --  Blossom visited William Tatcher on Jan 11th, 2021.
+
+INSERT INTO visits (vet_id, animal_id, visit_date)
+VALUES
+    ((SELECT id FROM vets WHERE name = 'William Tatcher'), (SELECT id FROM animals WHERE name = 'Agumon'), '2020-05-24'),
+    ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM animals WHERE name = 'Agumon'), '2020-07-22'),
+    ((SELECT id FROM vets WHERE name = 'Jack Harkness'), (SELECT id FROM animals WHERE name = 'Gabumon'), '2021-02-02'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Pikachu'), '2020-01-05'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Pikachu'), '2020-03-08'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Pikachu'), '2020-05-14'),
+    ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM animals WHERE name = 'Devimon'), '2021-05-04'),
+    ((SELECT id FROM vets WHERE name = 'Jack Harkness'), (SELECT id FROM animals WHERE name = 'Charmander'), '2021-02-24'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Plantmon'), '2019-12-21'),
+    ((SELECT id FROM vets WHERE name = 'William Tatcher'), (SELECT id FROM animals WHERE name = 'Plantmon'), '2020-08-10'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Plantmon'), '2021-04-07'),
+    ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM animals WHERE name = 'Squirtle'), '2019-09-29'),
+    ((SELECT id FROM vets WHERE name = 'Jack Harkness'), (SELECT id FROM animals WHERE name = 'Angemon'), '2020-10-03'),
+    ((SELECT id FROM vets WHERE name = 'Jack Harkness'), (SELECT id FROM animals WHERE name = 'Angemon'), '2020-11-04'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Boarmon'), '2019-01-24'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Boarmon'), '2019-05-15'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Boarmon'), '2020-02-27'),
+    ((SELECT id FROM vets WHERE name = 'Maisy Smith'), (SELECT id FROM animals WHERE name = 'Boarmon'), '2020-08-03'),
+    ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM animals WHERE name = 'Blossom'), '2020-05-24'),
+    ((SELECT id FROM vets WHERE name = 'William Tatcher'), (SELECT id FROM animals WHERE name = 'Blossom'), '2021-01-11');

--- a/data.sql
+++ b/data.sql
@@ -92,3 +92,9 @@ VALUES
     ('Jack Harkness', 38, '2008-06-08');
 
 
+-- Insert the following data for specializations:
+
+    --  Vet William Tatcher is specialized in Pokemon.
+    INSERT INTO specializations (vet_id, species_id)
+    VALUES ((SELECT id FROM vets WHERE name = 'William Tatcher'), 1);
+

--- a/data.sql
+++ b/data.sql
@@ -98,3 +98,7 @@ VALUES
     INSERT INTO specializations (vet_id, species_id)
     VALUES ((SELECT id FROM vets WHERE name = 'William Tatcher'), 1);
 
+    --  Vet Stephanie Mendez is specialized in Digimon and Pokemon.
+    INSERT INTO specializations (vet_id, species_id)
+    VALUES ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), 2);
+

--- a/data.sql
+++ b/data.sql
@@ -102,3 +102,6 @@ VALUES
     INSERT INTO specializations (vet_id, species_id)
     VALUES ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), 2);
 
+    INSERT INTO specializations (vet_id, species_id)
+    VALUES ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), 1);
+ 

--- a/data.sql
+++ b/data.sql
@@ -75,3 +75,20 @@ SET owner_id = CASE
     WHEN name IN ('Charmander', 'Squirtle', 'Blossom') THEN (SELECT id FROM owners WHERE full_name = 'Melody Pond')
     WHEN name IN ('Angemon', 'Boarmon') THEN (SELECT id FROM owners WHERE full_name = 'Dean Winchester')
 END;
+
+
+-- Insert the following data for vets:
+
+    --  Vet William Tatcher is 45 years old and graduated Apr 23rd, 2000.
+    --  Vet Maisy Smith is 26 years old and graduated Jan 17th, 2019.
+    --  Vet Stephanie Mendez is 64 years old and graduated May 4th, 1981.
+    --  Vet Jack Harkness is 38 years old and graduated Jun 8th, 2008.
+
+INSERT INTO vets (name, age, date_of_graduation)
+VALUES
+    ('William Tatcher', 45, '2000-04-23'),
+    ('Maisy Smith', 26, '2019-01-17'),
+    ('Stephanie Mendez', 64, '1981-05-04'),
+    ('Jack Harkness', 38, '2008-06-08');
+
+

--- a/queries.sql
+++ b/queries.sql
@@ -139,3 +139,85 @@ JOIN animals a ON o.id = a.owner_id
 GROUP BY o.id, o.full_name
 ORDER BY COUNT(a.id) DESC
 LIMIT 1;
+
+
+-- Write queries to answer the following:
+
+    --  Who was the last animal seen by William Tatcher?
+    SELECT a.name AS animal_name
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets vt ON v.vet_id = vt.id
+    WHERE vt.name = 'William Tatcher'
+    ORDER BY v.visit_date DESC
+    LIMIT 1;
+
+  --  How many different animals did Stephanie Mendez see?
+    SELECT COUNT(DISTINCT a.id)
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets vt ON v.vet_id = vt.id
+    WHERE vt.name = 'Stephanie Mendez';
+
+    --  List all vets and their specialties, including vets with no specialties.
+    SELECT vt.name, COALESCE(array_agg(s.name), ARRAY[]::text[]) AS specialties
+    FROM vets vt
+    LEFT JOIN vet_specialties vs ON vt.id = vs.vet_id
+    LEFT JOIN specialties s ON vs.specialty_id = s.id
+    GROUP BY vt.id, vt.name;
+
+     --  List all animals that visited Stephanie Mendez between April 1st and August 30th, 2020.
+    SELECT a.name AS animal_name
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets vt ON v.vet_id = vt.id
+    WHERE vt.name = 'Stephanie Mendez'
+    AND v.visit_date BETWEEN '2020-04-01' AND '2020-08-30';
+
+    --  What animal has the most visits to vets?
+    SELECT a.name AS animal_name, COUNT(*) AS visit_count
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    GROUP BY a.name
+    ORDER BY visit_count DESC
+    LIMIT 1;
+
+    --  Who was Maisy Smith's first visit?
+    SELECT a.name AS animal_name, MIN(v.visit_date) AS first_visit_date
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets vt ON v.vet_id = vt.id
+    WHERE vt.name = 'Maisy Smith'
+    GROUP BY a.name;
+
+
+    --  Details for most recent visit: animal information, vet information, and date of visit.
+    SELECT a.name AS animal_name, v.visit_date, ve.name AS vet_name
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets ve ON v.vet_id = ve.id
+    ORDER BY v.visit_date DESC
+    LIMIT 1;
+
+
+
+    --  How many visits were with a vet that did not specialize in that animal's species?
+    SELECT COUNT(*) AS mismatched_specialty_count
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets ve ON v.vet_id = ve.id
+    LEFT JOIN specializations s ON ve.id = s.vet_id AND a.species_id = s.species_id
+    WHERE s.species_id IS NULL;
+
+
+    --  What specialty should Maisy Smith consider getting? Look for the species she gets the most.
+    SELECT s.name AS specialty_name, COUNT(*) AS visit_count
+    FROM visits v
+    JOIN animals a ON v.animal_id = a.id
+    JOIN vets ve ON v.vet_id = ve.id
+    JOIN specializations sp ON ve.id = sp.vet_id
+    JOIN species s ON sp.species_id = s.id
+    WHERE a.name = 'Maisy Smith'
+    GROUP BY s.name
+    ORDER BY visit_count DESC
+    LIMIT 1;

--- a/queries.sql
+++ b/queries.sql
@@ -160,11 +160,10 @@ LIMIT 1;
     WHERE vt.name = 'Stephanie Mendez';
 
     --  List all vets and their specialties, including vets with no specialties.
-    SELECT vt.name, COALESCE(array_agg(s.name), ARRAY[]::text[]) AS specialties
-    FROM vets vt
-    LEFT JOIN vet_specialties vs ON vt.id = vs.vet_id
-    LEFT JOIN specialties s ON vs.specialty_id = s.id
-    GROUP BY vt.id, vt.name;
+    SELECT vets.name AS vet_name, species.name AS specialized_in
+    FROM specializations
+    FULL JOIN vets ON specializations.vet_id = vets.id
+    FULL JOIN species ON specializations.species_id = species.id;
 
      --  List all animals that visited Stephanie Mendez between April 1st and August 30th, 2020.
     SELECT a.name AS animal_name
@@ -183,12 +182,14 @@ LIMIT 1;
     LIMIT 1;
 
     --  Who was Maisy Smith's first visit?
-    SELECT a.name AS animal_name, MIN(v.visit_date) AS first_visit_date
-    FROM visits v
-    JOIN animals a ON v.animal_id = a.id
-    JOIN vets vt ON v.vet_id = vt.id
-    WHERE vt.name = 'Maisy Smith'
-    GROUP BY a.name;
+    SELECT MIN(visit_date) AS first_visited, animals.name AS animal 
+    FROM visits 
+    JOIN vets ON visits.vet_id = vets.id 
+    JOIN animals ON visits.animals_id = animals.id 
+    WHERE vets.name = 'Maisy Smith' 
+    GROUP BY animals.name 
+    ORDER BY first_visited ASC 
+    LIMIT 1;
 
 
     --  Details for most recent visit: animal information, vet information, and date of visit.
@@ -211,13 +212,12 @@ LIMIT 1;
 
 
     --  What specialty should Maisy Smith consider getting? Look for the species she gets the most.
-    SELECT s.name AS specialty_name, COUNT(*) AS visit_count
-    FROM visits v
-    JOIN animals a ON v.animal_id = a.id
-    JOIN vets ve ON v.vet_id = ve.id
-    JOIN specializations sp ON ve.id = sp.vet_id
-    JOIN species s ON sp.species_id = s.id
-    WHERE a.name = 'Maisy Smith'
-    GROUP BY s.name
-    ORDER BY visit_count DESC
-    LIMIT 1;
+SELECT species.name AS frequent_visit_to_specific_specialist, vets.name AS doctor_name 
+FROM animals
+JOIN visits ON animals.id = visits.animals_id 
+JOIN vets ON visits.vet_id = vets.id 
+JOIN species ON animals.species_id = species.id 
+WHERE vets.name = 'Maisy Smith' 
+GROUP BY species.name, vets.name 
+ORDER BY COUNT(species.name) DESC 
+LIMIT 1;

--- a/schema.sql
+++ b/schema.sql
@@ -62,3 +62,18 @@ ALTER TABLE animals DROP COLUMN species;
 ALTER TABLE animals ADD COLUMN species_id INTEGER REFERENCES species(id);
 
 ALTER TABLE animals ADD COLUMN owner_id INTEGER REFERENCES owners(id);
+
+
+
+-- Create a table named vets with the following columns:
+    -- id: integer (set it as autoincremented PRIMARY KEY)
+    -- name: string
+    -- age: integer
+    -- date_of_graduation: date
+
+CREATE TABLE vets (
+  id SERIAL PRIMARY KEY,
+  name TEXT,
+  age INTEGER,
+  date_of_graduation DATE
+);

--- a/schema.sql
+++ b/schema.sql
@@ -91,8 +91,8 @@ CREATE TABLE specializations (
 -- There is a many-to-many relationship between the tables animals and vets: an animal can visit multiple vets and one vet can be visited by multiple animals. Create a "join table" called visits to handle this relationship, it should also keep track of the date of the visit.
 
 CREATE TABLE visits (
+  id SERIAL PRIMARY KEY,
   vet_id INTEGER REFERENCES vets(id),
   animal_id INTEGER REFERENCES animals(id),
-  visit_date DATE,
-  PRIMARY KEY (vet_id, animal_id)
+  visit_date DATE
 );

--- a/schema.sql
+++ b/schema.sql
@@ -87,3 +87,12 @@ CREATE TABLE specializations (
   PRIMARY KEY (vet_id, species_id)
 );
 
+
+-- There is a many-to-many relationship between the tables animals and vets: an animal can visit multiple vets and one vet can be visited by multiple animals. Create a "join table" called visits to handle this relationship, it should also keep track of the date of the visit.
+
+CREATE TABLE visits (
+  vet_id INTEGER REFERENCES vets(id),
+  animal_id INTEGER REFERENCES animals(id),
+  visit_date DATE,
+  PRIMARY KEY (vet_id, animal_id)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -77,3 +77,13 @@ CREATE TABLE vets (
   age INTEGER,
   date_of_graduation DATE
 );
+
+
+-- There is a many-to-many relationship between the tables species and vets: a vet can specialize in multiple species, and a species can have multiple vets specialized in it. Create a "join table" called specializations to handle this relationship.
+
+CREATE TABLE specializations (
+  vet_id INTEGER REFERENCES vets(id),
+  species_id INTEGER REFERENCES species(id),
+  PRIMARY KEY (vet_id, species_id)
+);
+


### PR DESCRIPTION
In this pull request, I introduce significant changes to the database structure, including the creation of the `vets`, `specializations`, and `visits` tables. These changes facilitate the representation of relationships between vets, species, and animals, as well as tracking visits and specialties. SQL queries have been written to address specific questions related to these tables. Screenshots of the query results have been included in the Pull Request description for reference.

### Changes Made:

- Created a table named `vets` with columns: `id` (autoincremented PRIMARY KEY), `name` (string), `age` (integer), and `date_of_graduation` (date).
- Created a "join table" named `specializations` to handle the many-to-many relationship between vets and species.
- Created a "join table" named `visits` to handle the many-to-many relationship between animals and vets, including the date of the visit.
- Inserted data into the `vets` table for four veterinarians with their respective information.
- Inserted data into the `specializations` table to represent the specialties of certain vets.
- Inserted data into the `visits` table to represent visits of various animals to different vets.

### Screenshots:
Please reference comments for updated screenshots
